### PR TITLE
add show skipped to model scan

### DIFF
--- a/charts/pipelines/templates/tasks/model-scan.yaml
+++ b/charts/pipelines/templates/tasks/model-scan.yaml
@@ -19,5 +19,5 @@ spec:
     args:
     - |
       python3 -m pip install modelscan[tensorflow] numpy==1.26.4
-      modelscan -p $(params.APPLICATION_NAME).keras
+      modelscan -p $(params.APPLICATION_NAME).keras --show-skipped
 {{- end }}


### PR DESCRIPTION
By default modelscan outputs the following:

```
--- Summary ---

 No issues found! 🎉

--- Skipped --- 

Total skipped: 3 - run with --show-skipped to see the full list.
```

Adding the `--show-skipped` arg changes the output to:

```
--- Summary ---

 No issues found! 🎉

--- Skipped --- 

Total skipped: 3 - run with --show-skipped to see the full list.

Skipped files list:

The following file /workspace/output/jukebox.keras:metadata.json was skipped 
during a ModelScan scan: 
Model Scan did not scan file
The following file /workspace/output/jukebox.keras:config.json was skipped 
during a ModelScan scan: 
Model Scan did not scan file
The following file /workspace/output/jukebox.keras:model.weights.h5 was skipped 
during a hdf5 scan: 
Model Config not found
```

Nothing too crazy but it is probably good to know in the pipeline what items are being skipped