### PR TITLE
Update gitea-pipeline.yaml

### DIFF
--- a/charts/pipelines/templates/pipelines/gitea-pipeline.yaml
+++ b/charts/pipelines/templates/pipelines/gitea-pipeline.yaml
@@ -146,7 +146,9 @@ spec:
         - name: GIT_SHORT_REVISION
           value: "$(params.GIT_SHORT_REVISION)"
       runAfter:
+        {{- if eq .Values.unit_tests false }}
         - fetch-ds-pipeline-repository
+        {{- end }}
         {{- if eq .Values.apply_feature_changes true }}
         - apply-feature-changes
         {{- end }}


### PR DESCRIPTION
Making execute-ds-pipeline NOT show as run after fetch-ds-pipeline-repository if it's running after unit tests.